### PR TITLE
Round instead of parse to get correct rating.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 (function() {
-	
+
 
   function EloRank(k) {
 
-		if(!(this instanceof EloRank))
-			return new EloRank(k);
+	 if(!(this instanceof EloRank))
+	   return new EloRank(k);
 
     this.k = k || 32;
 		return this;
@@ -23,7 +23,7 @@
   }
 
   EloRank.prototype.updateRating = function(expected,actual,current) {
-    return parseInt(current+ this.k*(actual-expected),10);
+    return Math.round(current+ this.k*(actual-expected));
   }
 
   module.exports = EloRank;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,7 +1,7 @@
 var should = require('should'),
 		Elo = require('./../index');
 describe('elo',function(){
-	
+
 	it('should create instance without new',function() {
 		var elo = Elo();
 		elo.should.be.instanceOf(Elo);
@@ -44,7 +44,16 @@ describe('elo',function(){
 		var expectedA = elo.getExpected(1200,1400);
 		var expectedB = elo.getExpected(1400,1200);
 		elo.updateRating(expectedA,1,1200).should.equal(1224);
-		elo.updateRating(expectedB,0,1400).should.equal(1375);
+		elo.updateRating(expectedB,0,1400).should.equal(1376);
+	});
+
+
+	it('should round rating properly',function() {
+		var elo = Elo();
+		var expectedA = elo.getExpected(1802,1186);
+		var expectedB = elo.getExpected(1186,1802);
+		elo.updateRating(expectedA,1,1802).should.equal(1803);
+		elo.updateRating(expectedB,0,1186).should.equal(1185);
 	});
 
 });


### PR DESCRIPTION
This pull request rounds the rating in order to get the correct value. I ran into an issue when I had a player with high rating (1802) who played with the player with a lower rating (1186). With your previous implementation the rating of the player who won (1802) did not change because the new rating would always return 0.